### PR TITLE
ASoC: msm: qdsp6v2: check param length for EAC3

### DIFF
--- a/sound/soc/msm/qdsp6v2/msm-compr-q6-v2.c
+++ b/sound/soc/msm/qdsp6v2/msm-compr-q6-v2.c
@@ -1081,6 +1081,7 @@ static int msm_compr_ioctl(struct snd_pcm_substream *substream,
 				__func__, ddp->params_length);
 				return -EINVAL;
 			}
+			params_length = ddp->params_length*sizeof(int);
 			if (params_length > MAX_AC3_PARAM_SIZE) {
 				/*MAX is 36*sizeof(int) this should not happen*/
 				pr_err("%s: params_length(%d) is greater than %d\n",


### PR DESCRIPTION
https://github.com/SlimRoms/kernel_samsung_mondrianwifi/commit/241f0c0db531cd802aa4cd316b2e603f1354c4e4